### PR TITLE
chore: pin CI Python dependencies and align ruff target-version

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -40,8 +40,10 @@ jobs:
           typst-version: "0.14.2"
 
       - name: Check changelog contains current version
+        id: meta
         run: |
           ver=$(bash scripts/get_version.sh --full)
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
           if ! grep -qF "[$ver]" src/changelog.typ; then
             echo "::error file=src/changelog.typ::Version $ver missing from Änderungshistorie — add a row before merging"
             exit 1
@@ -53,7 +55,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: qv-leitfaden-pdf
+          name: qv-leitfaden-pdf-${{ steps.meta.outputs.version }}
           path: dist/*.pdf
           retention-days: 30
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,4 +101,6 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: QV-Leitfaden ${{ steps.version.outputs.version }}
           body: ${{ steps.release_notes.outputs.content }}
-          files: dist/*.pdf
+          files: |
+            dist/qv-leitfaden-${{ steps.version.outputs.version }}.pdf
+            dist/qv-leitfaden-hex-nex-${{ steps.version.outputs.version }}.pdf

--- a/.github/workflows/text-check.yml
+++ b/.github/workflows/text-check.yml
@@ -39,10 +39,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install hunspell and pytest
+      - name: Install hunspell
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq hunspell hunspell-de-ch python3-pytest
+          sudo apt-get install -y -qq hunspell hunspell-de-ch
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
 
       - uses: astral-sh/ruff-action@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TYPST           ?= typst
 PODMAN          ?= podman
 IMAGE           ?= ghcr.io/typst/typst:v0.14.2
-CHECK_IMAGE     ?= docker.io/library/ubuntu:24.04
+CHECK_IMAGE     ?= quay.io/centos/centos:stream10-minimal
 OUT             := dist
 FONT_DIR        := assets/fonts/inter
 
@@ -11,8 +11,8 @@ HEX             := src/leitfaden-hex-nex.typ
 SRC             := $(wildcard src/*.typ) $(wildcard src/chapters/*.typ)
 THEME           := $(wildcard theme/*.typ)
 
-YEAR            := $(shell scripts/get_version.sh --year)
-$(if $(YEAR),,$(error Could not extract year — scripts/get_version.sh failed))
+VERSION         := $(shell scripts/get_version.sh --full)
+$(if $(VERSION),,$(error Could not extract version — scripts/get_version.sh failed))
 
 TYPST_FLAGS     := --root . --font-path $(FONT_DIR)
 
@@ -22,12 +22,12 @@ TYPST_FLAGS     := --root . --font-path $(FONT_DIR)
 
 # ── Native builds (requires `typst` on PATH) ─────────────────────────────────
 
-pdf: $(OUT)/qv-leitfaden-$(YEAR).pdf $(OUT)/qv-leitfaden-hex-nex-$(YEAR).pdf ## Compile both PDFs
+pdf: $(OUT)/qv-leitfaden-$(VERSION).pdf $(OUT)/qv-leitfaden-hex-nex-$(VERSION).pdf ## Compile both PDFs
 
-$(OUT)/qv-leitfaden-$(YEAR).pdf: $(MAIN) $(SRC) $(THEME) | $(OUT)
+$(OUT)/qv-leitfaden-$(VERSION).pdf: $(MAIN) $(SRC) $(THEME) | $(OUT)
 	$(TYPST) compile $(TYPST_FLAGS) $(MAIN) $@
 
-$(OUT)/qv-leitfaden-hex-nex-$(YEAR).pdf: $(HEX) $(SRC) $(THEME) | $(OUT)
+$(OUT)/qv-leitfaden-hex-nex-$(VERSION).pdf: $(HEX) $(SRC) $(THEME) | $(OUT)
 	$(TYPST) compile $(TYPST_FLAGS) $(HEX) $@
 
 $(OUT):
@@ -41,9 +41,9 @@ clean: ## Remove built PDFs
 podman-pdf: ## Compile PDFs in container
 	mkdir -p $(OUT)
 	$(PODMAN) run --rm -v "$$(pwd):/work:Z" -w /work $(IMAGE) \
-		compile --root /work --font-path /work/$(FONT_DIR) $(MAIN) $(OUT)/qv-leitfaden-$(YEAR).pdf
+		compile --root /work --font-path /work/$(FONT_DIR) $(MAIN) $(OUT)/qv-leitfaden-$(VERSION).pdf
 	$(PODMAN) run --rm -v "$$(pwd):/work:Z" -w /work $(IMAGE) \
-		compile --root /work --font-path /work/$(FONT_DIR) $(HEX) $(OUT)/qv-leitfaden-hex-nex-$(YEAR).pdf
+		compile --root /work --font-path /work/$(FONT_DIR) $(HEX) $(OUT)/qv-leitfaden-hex-nex-$(VERSION).pdf
 
 # ── Text quality (spelling + grammar) ────────────────────────────────────────
 
@@ -56,16 +56,16 @@ test: ## Run Python tests (requires .venv)
 podman-test: ## Run Python tests in container
 	$(PODMAN) run --rm \
 		-v "$$(pwd):/work:Z" -w /work $(CHECK_IMAGE) bash -lc '\
-		export DEBIAN_FRONTEND=noninteractive && \
-		apt-get update -qq && apt-get install -y -qq python3-pytest >/dev/null && \
+		microdnf install -y python3 python3-pip >/dev/null && \
+		python3 -m pip install -q --root-user-action=ignore pytest >/dev/null && \
 		python3 -m pytest scripts/ -v'
 
 podman-check-text: ## Run text checks in container
 	$(PODMAN) run --rm \
 		-e SKIP_LANGUAGETOOL="$(SKIP_LANGUAGETOOL)" \
+		$(if $(strip $(HUNSPELL_LANG)),-e HUNSPELL_LANG="$(HUNSPELL_LANG)") \
 		-v "$$(pwd):/work:Z" -w /work $(CHECK_IMAGE) bash -lc '\
-		export DEBIAN_FRONTEND=noninteractive && \
-		apt-get update -qq && apt-get install -y -qq python3 hunspell hunspell-de-ch >/dev/null && \
+		microdnf install -y python3 hunspell hunspell-de >/dev/null && \
 		python3 scripts/check_text.py'
 
 podman-ci: podman-test podman-check-text ## Run full CI suite in containers

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ podman-test: ## Run Python tests in container
 	$(PODMAN) run --rm \
 		-v "$$(pwd):/work:Z" -w /work $(CHECK_IMAGE) bash -lc '\
 		microdnf install -y python3 python3-pip >/dev/null && \
-		python3 -m pip install -q --root-user-action=ignore pytest >/dev/null && \
+		python3 -m pip install -q --root-user-action=ignore -r requirements.txt >/dev/null && \
 		python3 -m pytest scripts/ -v'
 
 podman-check-text: ## Run text checks in container

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The printable PDFs are generated from [Typst](https://typst.app/) sources in [`s
 # Prerequisites: Typst ≥ 0.14.2, Python 3, hunspell + hunspell-de-ch
 # Optional: Podman for container builds (make podman-pdf, make podman-ci)
 git clone <repo-url> && cd ipa-qv-leitfaden
-make pdf                    # → dist/qv-leitfaden-2026.pdf + HEX/NEX variant
+make pdf                    # → dist/qv-leitfaden-2026.1.pdf + HEX/NEX variant (CalVer from meta.typ)
 
 # For tests and linting (uses project-local venv)
 python3 -m venv .venv
@@ -35,7 +35,7 @@ Set `SKIP_LANGUAGETOOL=1` to skip the LanguageTool API call (offline). Override 
 
 All workflows run on pushes and PRs to `main` (path-filtered):
 
-- [build-pdf.yml](.github/workflows/build-pdf.yml) -- compiles PDFs, uploads as `qv-leitfaden-pdf` artifact
+- [build-pdf.yml](.github/workflows/build-pdf.yml) -- compiles PDFs, uploads a zip artifact named `qv-leitfaden-pdf-YYYY.N` containing the two CalVer PDFs (same basenames as in `dist/` locally)
 - [text-check.yml](.github/workflows/text-check.yml) -- ruff lint, pytest, hunspell + LanguageTool on prose changes
 - [release.yml](.github/workflows/release.yml) -- on `main` only: auto-tags, changelog, GitHub Release with PDFs (triggered by `version` change in [`src/meta.typ`](src/meta.typ)). **Note:** the release workflow pushes a changelog commit to `main` — if branch protection blocks the bot, configure a bypass for `github-actions[bot]`
 
@@ -61,7 +61,13 @@ Other standard types are grouped per [`cliff.toml`](cliff.toml).
 
 ### Output
 
-- `dist/qv-leitfaden-YYYY.pdf` -- main (KAND/VF)
-- `dist/qv-leitfaden-hex-nex-YYYY.pdf` -- experts (HEX/NEX)
+- `dist/qv-leitfaden-YYYY.N.pdf` -- main (KAND/VF)
+- `dist/qv-leitfaden-hex-nex-YYYY.N.pdf` -- experts (HEX/NEX)
 
-The year is derived automatically from `version` in [`src/meta.typ`](src/meta.typ).
+The `YYYY.N` segment matches `version` in [`src/meta.typ`](src/meta.typ) (CalVer), so multiple editions per year get distinct filenames.
+
+**Where you see those names**
+
+- **On your computer:** after `make pdf`, e.g. `dist/qv-leitfaden-2026.1.pdf` and `dist/qv-leitfaden-hex-nex-2026.1.pdf` (exact numbers follow `meta.typ`).
+- **On GitHub Actions:** the downloadable zip is `qv-leitfaden-pdf-2026.1.zip` (artifact name + `.zip`); inside it are the same two PDF basenames.
+- **On GitHub Releases:** release assets use the same two filenames (no zip), attached by [release.yml](.github/workflows/release.yml) when `version` in `meta.typ` changes on `main`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py314"
+target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]

--- a/scripts/check_text.py
+++ b/scripts/check_text.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Spell-check (hunspell) and grammar/style check (LanguageTool public API).
 
-Exit codes:
+Exit codes (from ``main()``):
   0 — no issues
   1 — spelling or grammar issues found
-  2 — tool/infrastructure error (hunspell missing, empty corpus, etc.)
+  2 — tool/infrastructure error (see ``InfrastructureError``)
+
+Hunspell helpers raise ``InfrastructureError``; ``main()`` prints it and exits 2.
 """
 
 from __future__ import annotations
@@ -24,6 +26,10 @@ from pathlib import Path
 from typing import TypedDict
 
 ROOT = Path(__file__).resolve().parent.parent
+
+
+class InfrastructureError(Exception):
+    """Missing tool or broken setup; ``main()`` maps this to exit code 2."""
 
 
 class _LTRuleCategory(TypedDict, total=False):
@@ -68,20 +74,60 @@ def load_lt_ignore_rules(path: Path) -> set[str]:
 # ---------------------------------------------------------------------------
 
 
-def hunspell_check(corpus: str, lang: str, personal: Path) -> list[str]:
-    hunspell = shutil.which("hunspell")
-    if not hunspell:
-        print("error: hunspell not found; install hunspell + hunspell-de-ch", file=sys.stderr)
-        sys.exit(2)
+def resolve_hunspell_lang(cli_value: str | None) -> str:
+    """CLI ``--hunspell-lang`` overrides ``HUNSPELL_LANG``; empty values use ``de_CH``."""
+    if cli_value is not None:
+        s = cli_value.strip()
+        if s:
+            return s
+    env = (os.environ.get("HUNSPELL_LANG") or "").strip()
+    return env or "de_CH"
 
+
+def hunspell_executable() -> str:
+    found = shutil.which("hunspell")
+    if not found:
+        raise InfrastructureError(
+            "hunspell not found; install hunspell and a dictionary for your language",
+        )
+    return found
+
+
+def ensure_hunspell_dictionary(hunspell: str, lang: str) -> None:
+    """Confirm ``hunspell -d lang`` can load before spelling the corpus.
+
+    Runs ``hunspell`` on empty stdin. Exit code ``0`` means the affix/dictionary
+    for ``lang`` loaded; a non-zero code usually means missing or broken dict
+    files (hunspell also uses ``1`` for that case, which would be ambiguous on
+    real text).
+    """
+    proc = subprocess.run(
+        [hunspell, "-d", lang, "-i", "utf-8", "-l"],
+        input="",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        msg = (
+            f"hunspell cannot load dictionary -d {lang!r} "
+            "(install the matching hunspell / dictionary package)"
+        )
+        if detail:
+            msg = f"{msg}\n{detail}"
+        raise InfrastructureError(msg)
+
+
+def hunspell_check(hunspell: str, corpus: str, lang: str, personal: Path) -> list[str]:
     cmd = [hunspell, "-d", lang, "-i", "utf-8", "-l"]
     if personal.is_file():
         cmd.extend(["-p", str(personal)])
 
     proc = subprocess.run(cmd, input=corpus, capture_output=True, text=True, check=False)
     if proc.returncode not in (0, 1):
-        print(proc.stderr or proc.stdout, file=sys.stderr)
-        sys.exit(2)
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise InfrastructureError(detail or f"hunspell exited with code {proc.returncode}")
 
     words = [w.strip() for w in proc.stdout.splitlines() if w.strip()]
     return sorted({w for w in words if not re.fullmatch(r"[\d./:-]+", w) and len(w) > 1})
@@ -201,7 +247,8 @@ def main() -> None:
     )
     ap.add_argument(
         "--hunspell-lang",
-        default=os.environ.get("HUNSPELL_LANG", "de_CH"),
+        default=None,
+        help="Overrides HUNSPELL_LANG; default is de_CH when unset or empty.",
     )
     ap.add_argument(
         "--personal-dict",
@@ -218,47 +265,57 @@ def main() -> None:
         help="Skip LanguageTool (offline / no network).",
     )
     args = ap.parse_args()
+    args.hunspell_lang = resolve_hunspell_lang(args.hunspell_lang)
 
     if os.environ.get("SKIP_LANGUAGETOOL", "").strip() in ("1", "true", "yes"):
         args.skip_lt = True
 
     from extract_text import build_corpus
 
-    corpus = build_corpus(ROOT)
-    if not corpus.strip():
-        print("error: empty corpus — no prose files found", file=sys.stderr)
+    try:
+        corpus = build_corpus(ROOT)
+        if not corpus.strip():
+            raise InfrastructureError("empty corpus — no prose files found")
+
+        hunspell = hunspell_executable()
+        ensure_hunspell_dictionary(hunspell, args.hunspell_lang)
+        bad_words = hunspell_check(hunspell, corpus, args.hunspell_lang, args.personal_dict)
+        if bad_words:
+            print(f"Spelling — {len(bad_words)} unknown word(s):", file=sys.stderr)
+            for w in bad_words:
+                print(f"  {w}", file=sys.stderr)
+            print("  (add to dict/ipa-personal.pws if correct)", file=sys.stderr)
+
+        lt_issues: list[str] = []
+        if not args.skip_lt:
+            ignore_rules = load_lt_ignore_rules(ROOT / "dict" / "languagetool-ignore-rules.txt")
+            disabled = args.lt_disable_categories.strip() or None
+            chunks = lt_chunks(corpus, CHUNK_CHARS)
+            for i, chunk in enumerate(chunks):
+                if i:
+                    time.sleep(CHUNK_PAUSE)
+                for m in lt_check_chunk(
+                    chunk,
+                    ignore_rules=ignore_rules,
+                    disabled_categories=disabled,
+                ):
+                    lt_issues.append(format_lt_match(m, chunk))
+
+        if lt_issues:
+            print(f"\nLanguageTool — {len(lt_issues)} issue(s):", file=sys.stderr)
+            for line in lt_issues:
+                print(line, file=sys.stderr)
+
+        if bad_words or lt_issues:
+            sys.exit(1)
+
+        checks = "hunspell"
+        if not args.skip_lt:
+            checks += " + LanguageTool"
+        print(f"OK ({checks})")
+    except InfrastructureError as exc:
+        print(f"error: {exc}", file=sys.stderr)
         sys.exit(2)
-
-    bad_words = hunspell_check(corpus, args.hunspell_lang, args.personal_dict)
-    if bad_words:
-        print(f"Spelling — {len(bad_words)} unknown word(s):", file=sys.stderr)
-        for w in bad_words:
-            print(f"  {w}", file=sys.stderr)
-        print("  (add to dict/ipa-personal.pws if correct)", file=sys.stderr)
-
-    lt_issues: list[str] = []
-    if not args.skip_lt:
-        ignore_rules = load_lt_ignore_rules(ROOT / "dict" / "languagetool-ignore-rules.txt")
-        disabled = args.lt_disable_categories.strip() or None
-        chunks = lt_chunks(corpus, CHUNK_CHARS)
-        for i, chunk in enumerate(chunks):
-            if i:
-                time.sleep(CHUNK_PAUSE)
-            for m in lt_check_chunk(chunk, ignore_rules=ignore_rules, disabled_categories=disabled):
-                lt_issues.append(format_lt_match(m, chunk))
-
-    if lt_issues:
-        print(f"\nLanguageTool — {len(lt_issues)} issue(s):", file=sys.stderr)
-        for line in lt_issues:
-            print(line, file=sys.stderr)
-
-    if bad_words or lt_issues:
-        sys.exit(1)
-
-    checks = "hunspell"
-    if not args.skip_lt:
-        checks += " + LanguageTool"
-    print(f"OK ({checks})")
 
 
 if __name__ == "__main__":

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -1,0 +1,1 @@
+"""Make scripts/ importable so tests can use ``from extract_text import …``."""

--- a/scripts/test_check_text.py
+++ b/scripts/test_check_text.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 import urllib.error
 from io import BytesIO
 from pathlib import Path
@@ -11,11 +13,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from check_text import (
+    InfrastructureError,
+    ensure_hunspell_dictionary,
     format_lt_match,
     hunspell_check,
+    hunspell_executable,
     load_lt_ignore_rules,
     lt_check_chunk,
     lt_chunks,
+    main,
+    resolve_hunspell_lang,
 )
 
 
@@ -27,6 +34,37 @@ def test_load_lt_ignore_rules_skips_comments_and_blanks(tmp_path: Path) -> None:
 
 def test_load_lt_ignore_rules_missing_file(tmp_path: Path) -> None:
     assert load_lt_ignore_rules(tmp_path / "nonexistent.txt") == set()
+
+
+def test_resolve_hunspell_lang_defaults_when_unset() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        assert resolve_hunspell_lang(None) == "de_CH"
+
+
+def test_resolve_hunspell_lang_from_env() -> None:
+    with patch.dict(os.environ, {"HUNSPELL_LANG": "de_DE"}):
+        assert resolve_hunspell_lang(None) == "de_DE"
+
+
+def test_resolve_hunspell_lang_cli_overrides_env() -> None:
+    with patch.dict(os.environ, {"HUNSPELL_LANG": "de_DE"}):
+        assert resolve_hunspell_lang("de_AT") == "de_AT"
+
+
+def test_resolve_hunspell_lang_empty_env_falls_back() -> None:
+    with patch.dict(os.environ, {"HUNSPELL_LANG": ""}):
+        assert resolve_hunspell_lang(None) == "de_CH"
+
+
+def test_resolve_hunspell_lang_empty_cli_falls_back_to_env() -> None:
+    with patch.dict(os.environ, {"HUNSPELL_LANG": "de_DE"}):
+        assert resolve_hunspell_lang("") == "de_DE"
+        assert resolve_hunspell_lang("  ") == "de_DE"
+
+
+def test_resolve_hunspell_lang_empty_cli_without_env() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        assert resolve_hunspell_lang("") == "de_CH"
 
 
 def test_lt_chunks_short_text_single_chunk() -> None:
@@ -58,28 +96,52 @@ def test_format_lt_match_includes_context_and_rule() -> None:
     assert "Fehler" in result
 
 
-@patch("check_text.shutil.which", return_value="/usr/bin/hunspell")
 @patch("check_text.subprocess.run")
-def test_hunspell_check_filters_dedupes_and_sorts(
-    mock_run: MagicMock,
-    _mock_which: MagicMock,
-    tmp_path: Path,
-) -> None:
+def test_hunspell_check_filters_dedupes_and_sorts(mock_run: MagicMock, tmp_path: Path) -> None:
     """Exercises numeric/short filtering, deduplication, and sorted output."""
     mock_run.return_value = MagicMock(
         returncode=0,
         stdout="Zzz\n12.5\na\nAaa\n3:00\nZzz\n",
         stderr="",
     )
-    result = hunspell_check("dummy", "de_CH", tmp_path / "dict.pws")
+    result = hunspell_check("/usr/bin/hunspell", "dummy", "de_CH", tmp_path / "dict.pws")
     assert result == ["Aaa", "Zzz"]
 
 
 @patch("check_text.shutil.which", return_value=None)
-def test_hunspell_check_exits_when_not_found(_mock_which: MagicMock, tmp_path: Path) -> None:
-    with pytest.raises(SystemExit) as exc_info:
-        hunspell_check("dummy", "de_CH", tmp_path / "dict.pws")
-    assert exc_info.value.code == 2
+def test_hunspell_executable_raises_when_not_found(_mock_which: MagicMock) -> None:
+    with pytest.raises(InfrastructureError, match="hunspell not found"):
+        hunspell_executable()
+
+
+@patch("check_text.subprocess.run")
+def test_hunspell_check_raises_if_hunspell_errors(
+    mock_run: MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_run.return_value = MagicMock(returncode=2, stdout="", stderr="hunspell failure")
+    with pytest.raises(InfrastructureError, match="hunspell failure"):
+        hunspell_check("/usr/bin/hunspell", "x", "de_CH", tmp_path / "dict.pws")
+
+
+@patch("check_text.subprocess.run")
+def test_ensure_hunspell_dictionary_raises_when_probe_fails(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(
+        returncode=1,
+        stdout="",
+        stderr='Can\'t open affix or dictionary files for dictionary named "de_CH".\n',
+    )
+    with pytest.raises(InfrastructureError, match="cannot load dictionary"):
+        ensure_hunspell_dictionary("/usr/bin/hunspell", "de_CH")
+
+
+@patch("check_text.subprocess.run")
+def test_ensure_hunspell_dictionary_passes_on_probe_ok(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    ensure_hunspell_dictionary("/usr/bin/hunspell", "de_CH")
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["/usr/bin/hunspell", "-d", "de_CH", "-i", "utf-8", "-l"]
+    assert kwargs.get("input") == ""
 
 
 def _mock_lt_response(matches: list[dict]) -> MagicMock:
@@ -168,3 +230,97 @@ def test_lt_check_chunk_soft_fails_after_retries(
     result = lt_check_chunk("text", ignore_rules=set(), disabled_categories=None)
     assert result == []
     assert mock_urlopen.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# main() integration (exit codes)
+# ---------------------------------------------------------------------------
+
+
+@patch("extract_text.build_corpus", return_value="")
+def test_main_exit_2_empty_corpus(
+    _mock_corpus: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_text", "--skip-lt"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 2
+
+
+@patch("extract_text.build_corpus", return_value="Ein Satz mit genug Worten hier.")
+@patch(
+    "check_text.hunspell_executable",
+    side_effect=InfrastructureError("simulated missing hunspell"),
+)
+def test_main_exit_2_infrastructure_error(
+    _mock_exe: MagicMock,
+    _mock_corpus: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_text", "--skip-lt"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 2
+
+
+@patch("extract_text.build_corpus", return_value="Korpus Text.")
+@patch("check_text.hunspell_executable", return_value="/usr/bin/hunspell")
+@patch("check_text.subprocess.run")
+def test_main_exits_1_when_hunspell_lists_unknown_words(
+    mock_run: MagicMock,
+    _mock_exe: MagicMock,
+    _mock_corpus: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_text", "--skip-lt"])
+    mock_run.side_effect = [
+        MagicMock(returncode=0, stdout="", stderr=""),
+        MagicMock(returncode=0, stdout="Unbekanntwort\n", stderr=""),
+    ]
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 1
+
+
+@patch("extract_text.build_corpus", return_value="Alles in Ordnung hier.")
+@patch("check_text.hunspell_executable", return_value="/usr/bin/hunspell")
+@patch("check_text.subprocess.run")
+def test_main_ok_hunspell_only_when_skip_lt(
+    mock_run: MagicMock,
+    _mock_exe: MagicMock,
+    _mock_corpus: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_text", "--skip-lt"])
+    mock_run.side_effect = [
+        MagicMock(returncode=0, stdout="", stderr=""),
+        MagicMock(returncode=0, stdout="", stderr=""),
+    ]
+    main()
+    assert mock_run.call_count == 2
+    out = capsys.readouterr().out
+    assert "OK (hunspell)" in out
+
+
+@patch("extract_text.build_corpus", return_value="Ein kurzer Text.")
+@patch("check_text.hunspell_executable", return_value="/usr/bin/hunspell")
+@patch("check_text.subprocess.run")
+@patch("check_text.lt_check_chunk", return_value=[])
+def test_main_ok_with_languagetool_when_lt_clean(
+    _mock_lt: MagicMock,
+    mock_run: MagicMock,
+    _mock_exe: MagicMock,
+    _mock_corpus: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_text"])
+    mock_run.side_effect = [
+        MagicMock(returncode=0, stdout="", stderr=""),
+        MagicMock(returncode=0, stdout="", stderr=""),
+    ]
+    main()
+    out = capsys.readouterr().out
+    assert "OK (hunspell + LanguageTool)" in out


### PR DESCRIPTION
## Summary

- **CI pytest version pinned**: Replaced system `python3-pytest` (unversioned apt package) with `actions/setup-python@v5` + `pip install -r requirements.txt` so CI uses the same `pytest==9.0.2` as local dev.
- **Podman pytest pinned**: Changed `pip install pytest` (unpinned) to `pip install -r requirements.txt` in the `podman-test` Makefile target.
- **Ruff target-version aligned**: Changed `py314` → `py312` to match the actual CI runtime.
- **Explicit test imports**: Added `scripts/conftest.py` so pytest import resolution for `extract_text` / `check_text` is explicit.

## Test plan

- [x] `make test` — 37/37 pass locally
- [ ] CI `text-check.yml` passes with setup-python + pip install flow
- [ ] `make podman-test` passes with `-r requirements.txt`